### PR TITLE
Added ArgID learning rate as global parameter

### DIFF
--- a/configurations/global_config.json
+++ b/configurations/global_config.json
@@ -2,5 +2,6 @@
     "version": 1.7,
     "data_directory": "data/",
     "embeddings_file": "data/glove.6B.100d.txt",
+    "argid_lr": 0.0005,
     "debug_mode": false
 }

--- a/sesame/argid.py
+++ b/sesame/argid.py
@@ -30,7 +30,7 @@ from optparse import OptionParser
 from .conll09 import VOCDICT, FRAMEDICT, FEDICT, LUDICT, LUPOSDICT, DEPRELDICT, CLABELDICT, POSDICT, LEMDICT, lock_dicts, post_train_lock_dicts
 from .dataio import read_conll, get_wvec_map, read_ptb, read_frame_maps, read_frame_relations
 from .evaluation import calc_f, evaluate_example_argid, evaluate_corpus_argid
-from .globalconfig import VERSION, TRAIN_EXEMPLAR, TRAIN_FTE, TRAIN_FTE_CONSTITS, UNK, EMPTY_LABEL, EMPTY_FE, TEST_CONLL, DEV_CONLL
+from .globalconfig import VERSION, TRAIN_EXEMPLAR, TRAIN_FTE, TRAIN_FTE_CONSTITS, UNK, EMPTY_LABEL, EMPTY_FE, TEST_CONLL, DEV_CONLL, ARGID_LR
 from .housekeeping import Factor, filter_long_ex, unk_replace_tokens
 from .discrete_argid_feats import ArgPosition, OutHeads, SpanWidth
 from .raw_data import make_data_instance
@@ -261,7 +261,7 @@ print_data_status(DEPRELDICT, "Dependency Relations")
 sys.stderr.write("\n_____________________\n\n")
 
 model = dy.Model()
-adam = dy.AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8)
+adam = dy.AdamTrainer(model, ARGID_LR, 0.01, 0.9999, 1e-8)
 
 v_x = model.add_lookup_parameters((VOCDICT.size(), TOKDIM))
 p_x = model.add_lookup_parameters((POSDICT.size(), POSDIM))
@@ -1083,3 +1083,4 @@ elif options.mode == "predict":
     sys.stderr.write("Printing output in CoNLL format to {}\n".format(out_conll_file))
     print_as_conll(instances, predictions)
     sys.stderr.write("Done!\n")
+

--- a/sesame/globalconfig.py
+++ b/sesame/globalconfig.py
@@ -24,6 +24,7 @@ VERSION = str(configuration["version"])
 DATA_DIR = configuration["data_directory"]
 EMBEDDINGS_FILE = configuration["embeddings_file"]
 DEBUG_MODE = configuration["debug_mode"]
+ARGID_LR = configuration["argid_lr"]
 
 # The following variables are held constant throughout the repository. Change at your own peril!
 


### PR DESCRIPTION
In configurations/global_config.json, I added a parameter "argid_lr" that corresponds to the learning rate of ArgId. The python script sesame/globalconfig.py has been updated to store this parameter as "ARGID_LR" and sesame/argid.py now uses "ARGID_LR" as the learning rate conveyed to AdamTrainer. I've left the default learning rate as 0.0005, as openSESAME originally used.