### PR TITLE
Fixed Broken Download Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ cd open-sesame/
 
 1. Create a directory for the data, `$DATA`, containing the (extracted) [FrameNet version 1.7](https://drive.google.com/open?id=1s4SDt_yDhT8qFs1MZJbeFf-XeiNPNnx7) data. This should be under `$DATA/fndata-1.7/`.
 
-2. Second, this project uses pretrained [GloVe word embeddings](https://nlp.stanford.edu/projects/glove/) of 100 dimensions, trained on 6B tokens. [Download](http://nlp.stanford.edu/data/glove.6B.100d.zip) and extract under `$DATA/embeddings_glove/`.
+2. Second, this project uses pretrained [GloVe word embeddings](https://nlp.stanford.edu/projects/glove/) of 100 dimensions, trained on 6B tokens. [Download](https://nlp.stanford.edu/data/glove.6B.zip) and move the extracted file `glove.6B.100d.txt` into the `$DATA` folder.
 
 3. Optionally, make alterations to the configurations in `configurations/global_config.json`, if you have decided to either use a different version of FrameNet, or different pretrained embeddings, and so on.
 


### PR DESCRIPTION
- fixed broken download link for the embeddings
- fixed correct folder name (`$DATA` instead of `$DATA/embeddings_glove`) for the folder the embedding file needs to be extracted to as otherwise an exception is raised (`"Pretrained embeddings file not found!"`)