### PR TITLE
fix preprocess byte encoding on python 3

### DIFF
--- a/sesame/preprocess.py
+++ b/sesame/preprocess.py
@@ -76,7 +76,7 @@ def write_to_conll(outf, fsp, firstex, sentid):
             token, postag, nltkpostag, nltklemma, lu, frm, role = fsp.info_at_idx(i)
 
             outf.write(str(i + 1) + "\t")  # ID = 0
-            outf.write(str(token.encode('utf-8')) + "\t")  # FORM = 1
+            outf.write(str(token) + "\t")  # FORM = 1
             outf.write("_\t" + nltklemma + "\t")  # LEMMA PLEMMA = 2,3
             outf.write(postag + "\t" + nltkpostag + "\t")  # POS PPOS = 4,5
             outf.write(str(sentid - 1) + "\t_\t")  # FEAT PFEAT = 6,7 ~ replacing FEAT with sentence number


### PR DESCRIPTION
This PR fixes a bug in the preprocess step for Python 3, which is writing tokens as `b'token'` instead of just `token`, as pointed out in @appleternity in https://github.com/swabhs/open-sesame/issues/61#issuecomment-789312514. [Python 2 is officially dead as of Jan 1, 2020](https://www.python.org/doc/sunset-python-2/), so it should be a priority to make sure that this code works on Python 3 rather than 2. 